### PR TITLE
Add Google Maps API key support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: node_js
 node_js:
-  - "0.11"
-  - "0.10"
+  - "6.11.1"
 notifications:
   email: false

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Add **hubot-darksky** to your `external-scripts.json`:
 ## Configuration
 - `HUBOT_DARK_SKY_API_KEY` an api key from [darksky.net](https://darksky.net/dev)
 - `HUBOT_DARK_SKY_DEFAULT_LOCATION` if unset, `weather` commands without a location will be ignored
+- `HUBOT_DARK_SKY_GOOGLE_MAPS_GEOCODING_API_KEY` a [Google Maps Geocoding API Key](https://developers.google.com/maps/documentation/geocoding/get-api-key)
 - `HUBOT_DARK_SKY_SEPARATOR` a configurable line separator for responses.  defaults to "\n"
 
 ## Sample Interaction

--- a/src/darksky.coffee
+++ b/src/darksky.coffee
@@ -31,9 +31,9 @@ module.exports = (robot) ->
       options.separator = "\n"
 
     google_api_key = process.env.HUBOT_DARK_SKY_GOOGLE_MAPS_GEOCODING_API_KEY || ''
-    googleurl = "https://maps.googleapis.com/maps/api/geocode/json"
+    google_url = "https://maps.googleapis.com/maps/api/geocode/json"
     q = sensor: false, address: location, key: google_api_key
-    msg.http(googleurl)
+    msg.http(google_url)
       .query(q)
       .get() (err, res, body) ->
         result = JSON.parse(body)
@@ -41,28 +41,27 @@ module.exports = (robot) ->
         if result.results.length > 0
           lat = result.results[0].geometry.location.lat
           lng = result.results[0].geometry.location.lng
-          darkSkyMe msg, lat,lng , options.separator, (darkSkyText) ->
-            response = "Weather for #{result.results[0].formatted_address} (Powered by DarkSky https://darksky.net/poweredby/)#{options.separator}#{darkSkyText}"
-              .replace /-?(\d+\.?\d*)°C/g, (match) ->
-                centigrade = match.replace /°C/, ''
-                match = Math.round(centigrade*10)/10 + '°C/' + Math.round(centigrade * (9/5) + parseInt(32, 10)) + '°F'
-            response += "#{options.separator}"
-            msg.send response
+          lookupWeatherAndRespond msg, lat, lng, options.separator, result.results[0].formatted_address
         else
           msg.send "Couldn't find #{location}"
           console.log("hubot-darksky google geocoding result: " + JSON.stringify(result))
 
-darkSkyMe = (msg, lat, lng, separator, cb) ->
+lookupWeatherAndRespond = (msg, lat, lng, separator, geocoded_address) ->
   url = "https://api.darksky.net/forecast/#{process.env.HUBOT_DARK_SKY_API_KEY}/#{lat},#{lng}/?units=si"
   msg.http(url)
     .get() (err, res, body) ->
       result = JSON.parse(body)
 
       if result.error
-        cb "#{result.error}"
+        msg.send "#{result.error}"
         return
 
-      response = "Currently: #{result.currently.summary} #{result.currently.temperature}°C"
+      response = "Weather for #{geocoded_address} (Powered by DarkSky https://darksky.net/poweredby/)"
+      response += "#{separator}Currently: #{result.currently.summary} #{result.currently.temperature}°C"
       response += "#{separator}Today: #{result.hourly.summary}"
       response += "#{separator}Coming week: #{result.daily.summary}"
-      cb response
+      response = response.replace /-?(\d+\.?\d*)°C/g, (match) ->
+          centigrade = match.replace /°C/, ''
+          match = Math.round(centigrade*10)/10 + '°C/' + Math.round(centigrade * (9/5) + parseInt(32, 10)) + '°F'
+
+      msg.send response

--- a/src/darksky.coffee
+++ b/src/darksky.coffee
@@ -7,6 +7,7 @@
 # Configuration
 #   HUBOT_DARK_SKY_API_KEY
 #   HUBOT_DARK_SKY_DEFAULT_LOCATION
+#   HUBOT_DARK_SKY_GOOGLE_MAPS_GEOCODING_API_KEY
 #   HUBOT_DARK_SKY_SEPARATOR (optional - defaults to "\n")
 #
 # Commands:
@@ -29,8 +30,9 @@ module.exports = (robot) ->
     unless options.separator
       options.separator = "\n"
 
-    googleurl = "http://maps.googleapis.com/maps/api/geocode/json"
-    q = sensor: false, address: location
+    google_api_key = process.env.HUBOT_DARK_SKY_GOOGLE_MAPS_GEOCODING_API_KEY || ''
+    googleurl = "https://maps.googleapis.com/maps/api/geocode/json"
+    q = sensor: false, address: location, key: google_api_key
     msg.http(googleurl)
       .query(q)
       .get() (err, res, body) ->
@@ -48,6 +50,7 @@ module.exports = (robot) ->
             msg.send response
         else
           msg.send "Couldn't find #{location}"
+          console.log("hubot-darksky google geocoding result: " + JSON.stringify(result))
 
 darkSkyMe = (msg, lat, lng, separator, cb) ->
   url = "https://api.darksky.net/forecast/#{process.env.HUBOT_DARK_SKY_API_KEY}/#{lat},#{lng}/?units=si"


### PR DESCRIPTION
I've been getting a lot of "rate limited" errors from Google lately, so this allows (optional) usage of a Google Maps Geocoding API key.  I also (in a separate commit) did a little refactoring so the response-building code is grouped together instead of split up between the two functions.